### PR TITLE
Don't download None profile picture

### DIFF
--- a/vscoscrape/vscoscrape.py
+++ b/vscoscrape/vscoscrape.py
@@ -144,6 +144,7 @@ class Scraper(object):
                     url["profile_image_id"]
                 ] = date.today().strftime("%m-%d-%Y")
         if (
+            url["profile_image_id"] == None or
             "%s.jpg" % url["profile_image_id"] in os.listdir()
         ):
             return True


### PR DESCRIPTION
For non-existent accounts or a profile without a profile picture, we do not need to download VSCO's default profile picture. This can be a problem if you want to scrape hundreds of profiles. This "none image" is called None.jpg and it allocates 4.2 KB for each profile.